### PR TITLE
Fix POST /tasks title validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,10 +24,15 @@ def get_tasks():
 @app.route("/tasks", methods=["POST"])
 def create_task():
     global next_id
-    data = request.get_json()
+    data = request.get_json() or {}
+
+    title = data.get("title")
+    if title == "" or title is None:
+        return jsonify({"error": "title is required"}), 400
+
     task = {
         "id": next_id,
-        "title": data["title"],           # KeyError if "title" missing -> 500
+        "title": title,
         "description": data.get("description", ""),
         "completed": False,
     }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,10 +2,12 @@
 Tests for Task Manager API.
 NOTE: Only two tests exist. More are needed (see GitHub Issues).
 """
-import pytest
-import sys
 import os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..')
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 import app as app_module
 from app import app
 
@@ -36,6 +38,20 @@ def test_create_task(client):
     assert data["title"] == "Fix the login bug"
     assert data["completed"] is False
     assert "id" in data
+
+
+def test_create_task_missing_title_returns_bad_request(client):
+    response = client.post("/tasks", json={"description": "Missing title"})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "title is required"}
+
+
+def test_create_task_empty_title_returns_bad_request(client):
+    response = client.post("/tasks", json={"title": "", "description": "Empty title"})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "title is required"}
 
 
 def test_get_tasks_empty(client):


### PR DESCRIPTION
### Motivation
- The `POST /tasks` endpoint raised a `KeyError` and returned 500 when the JSON body omitted `title` or provided an empty string, which is invalid input handling.
- The change implements the acceptance criteria to return `400` with `{"error": "title is required"}` for missing or empty `title` while preserving successful `201` behavior for valid requests.

### Description
- In `app.py` `create_task()` now uses `data = request.get_json() or {}` and validates `title` with `if title == "" or title is None:` returning `jsonify({"error": "title is required"}), 400` when invalid.
- The task creation now uses the validated `title` variable instead of indexing `data` directly to avoid `KeyError` and preserve existing `201` responses for valid input.
- `tests/test_app.py` import syntax was fixed and two tests were added: `test_create_task_missing_title_returns_bad_request` and `test_create_task_empty_title_returns_bad_request`, covering the missing and empty `title` cases while keeping existing tests.

### Testing
- Ran the test suite with `pytest tests/ -v` and all tests passed.
- The run produced 4 passed tests, verifying `201` for a valid create, `400` for missing `title`, `400` for empty `title`, and `200` for `GET /tasks` when empty.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcb0c64dbc8330960ebfcf1ac723ac)