### PR TITLE
Fix toggle behavior for PATCH /tasks/<id>/complete

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,7 +52,7 @@ def complete_task(task_id):
     task = next((t for t in tasks if t["id"] == task_id), None)
     if task is None:
         return jsonify({"error": "Task not found"}), 404
-    task["completed"] = True   # BUG: should be  not task["completed"]
+    task["completed"] = not task["completed"]
     return jsonify(task)
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,7 +5,7 @@ NOTE: Only two tests exist. More are needed (see GitHub Issues).
 import pytest
 import sys
 import os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..')
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 import app as app_module
 from app import app
 
@@ -44,3 +44,24 @@ def test_get_tasks_empty(client):
     assert response.status_code == 200
     data = response.get_json()
     assert data["tasks"] == []
+
+
+def test_complete_task_toggles_completed_state(client):
+    """Test PATCH /tasks/<id>/complete toggles completed on each call."""
+    create_response = client.post(
+        "/tasks",
+        json={"title": "Toggle completion", "description": "Verify toggle behavior"},
+    )
+    task_id = create_response.get_json()["id"]
+
+    first_response = client.patch(f"/tasks/{task_id}/complete")
+    assert first_response.status_code == 200
+    assert first_response.get_json()["completed"] is True
+
+    second_response = client.patch(f"/tasks/{task_id}/complete")
+    assert second_response.status_code == 200
+    assert second_response.get_json()["completed"] is False
+
+    third_response = client.patch(f"/tasks/{task_id}/complete")
+    assert third_response.status_code == 200
+    assert third_response.get_json()["completed"] is True


### PR DESCRIPTION
### Motivation
- The `PATCH /tasks/<id>/complete` endpoint always set `completed = True` instead of toggling, which failed the expected flip behavior across repeated calls.
- A regression test was needed to validate the toggle sequence (`False -> True -> False -> True`).
- The test module had a small import-path syntax error that prevented proper test collection.

### Description
- Update `complete_task` to toggle the flag using `task["completed"] = not task["completed"]` instead of hardcoding `True` (in `app.py`).
- Add `test_complete_task_toggles_completed_state` to `tests/test_app.py` which creates a task and calls `PATCH /tasks/<id>/complete` three times asserting `True`, then `False`, then `True`.
- Fix the `sys.path.insert` line in `tests/test_app.py` by closing the parentheses so the test module imports correctly.

### Testing
- Ran `pytest tests/ -v` which collected and ran the suite; all tests passed.
- Test results: `3 passed` (including the new toggle regression test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcb49630408330b6e133752ff1ad5c)